### PR TITLE
Add a few stuffs that might be useful while using aspeak as a library.

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -50,14 +50,16 @@ This function is used to synthesize the speech directly from the text, without c
 
 ```python
 def pure_text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, text: str,
-                        locale: Union[str, None] = None, voice: Union[str, None] = None,
+                        locale: Optional[str] = None, voice: Optional[str] = None,
+                        use_async: bool = False,
                         audio_format: Union[
                             AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None] = None) \
-        -> speechsdk.SpeechSynthesisResult:
+        -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
     ...
 ```
 - `locale` format: e.g. `en-US`, `zh-CN`
 - `voice` format: e.g. `en-US-JennyNeural`, execute `aspeak -L` to see available voices.
+- `use_async` : set it to `True` for using non-blocking (asynchronous) audio synthesizer
 - `audio_format`: See [Custom Audio Format](#custom-audio-format)
 
 If you specify the `voice`, there is no need to specify the `locale`.
@@ -70,10 +72,11 @@ with conversion to SSML, which provides more options to customize.
 ```python
 def text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, text: str, voice: str,
                    rate: Union[str, float] = 0.0, pitch: Union[str, float] = 0.0, style: str = "general",
-                   style_degree: Union[float, None] = None,
-                   role: Union[str, None] = None,
+                   style_degree: Optional[float] = None,
+                   role: Optional[str] = None,
+                   use_async: bool = False,
                    audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None] = None) \
-        -> speechsdk.SpeechSynthesisResult:
+        -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
     ...
 ```
 
@@ -113,6 +116,7 @@ It is a floating point number between 0.01 and 2, inclusive.
 changed.
   - At the time of writing, role adjustments are supported for these Chinese (Mandarin, Simplified) neural voices:
 `zh-CN-XiaomoNeural`, `zh-CN-XiaoxuanNeural`, `zh-CN-YunxiNeural`, and `zh-CN-YunyeNeural`.
+- `use_async` : set it to `True` for using non-blocking (asynchronous) audio synthesizer
 - `audio_format`: See [Custom Audio Format](#custom-audio-format)
 
 
@@ -122,8 +126,9 @@ This function is used to synthesize the speech from the SSML. Using SSML directl
 
 ```python
 def ssml_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, ssml: str,
-                   audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None]) \
-        -> speechsdk.SpeechSynthesisResult:
+                   audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None],
+                   use_async: bool = False) \
+        -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
     ...
 ```
 

--- a/src/aspeak/api/functional.py
+++ b/src/aspeak/api/functional.py
@@ -10,9 +10,10 @@ from ..ssml import create_ssml
 # pylint: disable=too-many-arguments
 def pure_text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, text: str,
                         locale: Union[str, None] = None, voice: Union[str, None] = None,
+                        use_async: bool = False,
                         audio_format: Union[
                             AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None] = None) \
-        -> speechsdk.SpeechSynthesisResult:
+        -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
     """
     Execute a text-to-speech request without SSML.
     :param provider: An instance of SpeechServiceProvider.
@@ -20,8 +21,9 @@ def pure_text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio
     :param text: The text to be synthesized.
     :param locale: The locale of the voice, optional.
     :param voice: The voice name, optional.
+    :param use_async: Use non-blocking (asynchronous) audio synthesizer, optional.
     :param audio_format: The audio format, optional.
-    :return: result of type SpeechSynthesisResult.
+    :return: result either of type SpeechSynthesisResult or ResultFuture.
     """
     cfg = speechsdk.SpeechConfig(auth_token=provider.token.token, region=provider.token.region)
     if locale is not None:
@@ -29,7 +31,7 @@ def pure_text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio
     if voice is not None:
         cfg.speech_synthesis_voice_name = voice
     cfg.set_speech_synthesis_output_format(parse_format(audio_format))
-    return provider.text_to_speech(text, cfg, output)
+    return provider.text_to_speech(text, cfg, output, use_async=use_async)
 
 
 # pylint: disable=too-many-arguments
@@ -37,8 +39,9 @@ def text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.Audi
                    rate: Union[str, float] = 0.0, pitch: Union[str, float] = 0.0, style: str = "general",
                    style_degree: Union[float, None] = None,
                    role: Union[str, None] = None,
+                   use_async: bool = False,
                    audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None] = None) \
-        -> speechsdk.SpeechSynthesisResult:
+        -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
     """
     Execute a text-to-speech request with generated SSML from text and various options.
     :param provider: An instance of SpeechServiceProvider.
@@ -50,26 +53,29 @@ def text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.Audi
     :param style: The speaking style, optional. See the documentation for more details.
     :param style_degree: The speaking style degree, optional. It only works for some Chinese voices.
     :param role: The speaking role, optional. It only works for some Chinese voices.
+    :param use_async: Use non-blocking (asynchronous) audio synthesizer, optional.
     :param audio_format: The audio format, optional.
-    :return: result of type SpeechSynthesisResult.
+    :return: result either of type SpeechSynthesisResult or ResultFuture.
     """
     ssml = create_ssml(text, voice, rate, pitch, style, style_degree, role)
     cfg = speechsdk.SpeechConfig(auth_token=provider.token.token, region=provider.token.region)
     cfg.set_speech_synthesis_output_format(parse_format(audio_format))
-    return provider.ssml_to_speech(ssml, cfg, output)
+    return provider.ssml_to_speech(ssml, cfg, output, use_async=use_async)
 
 
 def ssml_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, ssml: str,
-                   audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None]) \
-        -> speechsdk.SpeechSynthesisResult:
+                   audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None],
+                   use_async: bool = False) \
+        -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
     """
     Execute a text-to-speech request with SSML.
     :param provider: An instance of SpeechServiceProvider.
     :param output: An instance of AudioOutputConfig.
     :param ssml: The SSML to be synthesized.
+    :param use_async: Use non-blocking (asynchronous) audio synthesizer, optional.
     :param audio_format: The audio format, optional.
-    :return: result of type SpeechSynthesisResult.
+    :return: result either of type SpeechSynthesisResult or ResultFuture.
     """
     cfg = speechsdk.SpeechConfig(auth_token=provider.token.token, region=provider.token.region)
     cfg.set_speech_synthesis_output_format(parse_format(audio_format))
-    return provider.ssml_to_speech(ssml, cfg, output)
+    return provider.ssml_to_speech(ssml, cfg, output, use_async=use_async)

--- a/src/aspeak/api/functional.py
+++ b/src/aspeak/api/functional.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 import azure.cognitiveservices.speech as speechsdk
 
@@ -9,7 +9,7 @@ from ..ssml import create_ssml
 
 # pylint: disable=too-many-arguments
 def pure_text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, text: str,
-                        locale: Union[str, None] = None, voice: Union[str, None] = None,
+                        locale: Optional[str] = None, voice: Optional[str] = None,
                         use_async: bool = False,
                         audio_format: Union[
                             AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None] = None) \
@@ -37,8 +37,8 @@ def pure_text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio
 # pylint: disable=too-many-arguments
 def text_to_speech(provider: SpeechServiceProvider, output: speechsdk.audio.AudioOutputConfig, text: str, voice: str,
                    rate: Union[str, float] = 0.0, pitch: Union[str, float] = 0.0, style: str = "general",
-                   style_degree: Union[float, None] = None,
-                   role: Union[str, None] = None,
+                   style_degree: Optional[float] = None,
+                   role: Optional[str] = None,
                    use_async: bool = False,
                    audio_format: Union[AudioFormat, FileFormat, speechsdk.SpeechSynthesisOutputFormat, None] = None) \
         -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:

--- a/src/aspeak/api/provider.py
+++ b/src/aspeak/api/provider.py
@@ -1,3 +1,4 @@
+from typing import Union
 import azure.cognitiveservices.speech as speechsdk
 
 from ..token import Token
@@ -33,14 +34,23 @@ class SpeechServiceProvider:
         """
         self._current_token.renew()
 
+
     def text_to_speech(self, text: str, cfg: speechsdk.SpeechConfig,
-                       output: speechsdk.audio.AudioOutputConfig) -> speechsdk.SpeechSynthesisResult:
+                       output: speechsdk.audio.AudioOutputConfig,
+                       use_async: bool = False) -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
         if self._expired:
             self.renew()
-        return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_text(text)
+        if use_async:
+            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_text_async(text)
+        else:
+            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_text(text)
 
     def ssml_to_speech(self, ssml: str, cfg: speechsdk.SpeechConfig,
-                       output: speechsdk.audio.AudioOutputConfig) -> speechsdk.SpeechSynthesisResult:
+                       output: speechsdk.audio.AudioOutputConfig,
+                       use_async: bool = False) -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
         if self._expired:
             self.renew()
-        return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_ssml(ssml)
+        if use_async:
+            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_ssml_async(ssml)
+        else:
+            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_ssml(ssml)

--- a/src/aspeak/api/provider.py
+++ b/src/aspeak/api/provider.py
@@ -34,23 +34,26 @@ class SpeechServiceProvider:
         """
         self._current_token.renew()
 
+    def get_synthesizer(self, cfg: speechsdk.SpeechConfig,
+                       output: speechsdk.audio.AudioOutputConfig) -> speechsdk.SpeechSynthesizer:
+        if self._expired:
+            self.renew()
+        return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output)
 
     def text_to_speech(self, text: str, cfg: speechsdk.SpeechConfig,
                        output: speechsdk.audio.AudioOutputConfig,
                        use_async: bool = False) -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
-        if self._expired:
-            self.renew()
+        synthesizer = self.get_synthesizer(cfg, output)
         if use_async:
-            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_text_async(text)
+            return synthesizer.speak_text_async(text)
         else:
-            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_text(text)
+            return synthesizer.speak_text(text)
 
     def ssml_to_speech(self, ssml: str, cfg: speechsdk.SpeechConfig,
                        output: speechsdk.audio.AudioOutputConfig,
                        use_async: bool = False) -> Union[speechsdk.SpeechSynthesisResult, speechsdk.ResultFuture]:
-        if self._expired:
-            self.renew()
+        synthesizer = self.get_synthesizer(cfg, output)
         if use_async:
-            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_ssml_async(ssml)
+            return synthesizer.speak_ssml_async(ssml)
         else:
-            return speechsdk.SpeechSynthesizer(speech_config=cfg, audio_config=output).speak_ssml(ssml)
+            return synthesizer.speak_ssml(ssml)

--- a/src/aspeak/ssml.py
+++ b/src/aspeak/ssml.py
@@ -1,10 +1,10 @@
-from typing import Union
+from typing import Optional, Union
 from xml.sax.saxutils import escape
 
 
 # pylint: disable=too-many-arguments
-def create_ssml(text: str, voice: Union[str, None], rate: Union[float, str], pitch: Union[float, str],
-                style: str = "general", style_degree: Union[float, None] = None, role: Union[str, None] = None) -> str:
+def create_ssml(text: str, voice: Optional[str], rate: Union[float, str], pitch: Union[float, str],
+                style: str = "general", style_degree: Optional[float] = None, role: Optional[str] = None) -> str:
     """
     Create SSML for text to be spoken.
     """


### PR DESCRIPTION
- add [async flag](https://github.com/kxxt/aspeak/commit/ae50fee554bcbbb5cdb3e9a910c5df507fad5e4b)
- method for [speech synthesizer](https://github.com/kxxt/aspeak/commit/423c0b6e70cd2cc0a45e47c219ae9f1bd211a789)
- refactor typing
- updated docs

__Example usage__:
```python
from azure.cognitiveservices.speech import ResultReason, audio
from aspeak import SpeechServiceProvider, text_to_speech, AudioFormat, FileFormat, AspeakError

if __name__ == "__main__":
    try:
        output = audio.AudioOutputConfig(use_default_speaker=True)
        provider = SpeechServiceProvider()
        result = text_to_speech(provider, output, "Hello World! I am using aspeak to synthesize speech.", use_async=True,
                                voice="en-US-JennyNeural", rate="+10%", pitch="-5%", style="cheerful",
                                audio_format=AudioFormat(FileFormat.WAV, 1))
        print("Synthesis started and the workflow isn't blocked.")
        result = result.get() # Wait for the synthesis to complete
        if result.reason != ResultReason.SynthesizingAudioCompleted:
            print("Failed to synthesize speech.")
    except AspeakError:
        print("Error occurred while synthesizing speech.")
```