### PR TITLE
Use correct function at ssml_to_speech_async

### DIFF
--- a/src/aspeak/api/api.py
+++ b/src/aspeak/api/api.py
@@ -52,7 +52,7 @@ class SpeechServiceBase:
         return self._synthesizer.speak_ssml(ssml)
 
     def ssml_to_speech_async(self, ssml, **kwargs):
-        return self._synthesizer.speak_ssml(ssml)
+        return self._synthesizer.speak_ssml_async(ssml)
 
     def text_to_speech(self, text, **kwargs):
         """


### PR DESCRIPTION
I updated to the latest version, and found both example for ssml_to_speech_async and my own code couldn't run correctly.
I found in api/api.py file function ssml_to_speech_async uses speak_ssml not speak_ssml_async, and I think this is the reason.