### PR TITLE
Use self-built TTS instead of `azure.cognitiveservices.speech`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-azure-cognitiveservices-speech >= 1.20.0
-requests
+git+https://github.com/flt6/tts_rebuild
 Deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,7 @@ package_dir =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    requests
-    azure-cognitiveservices-speech >= 1.20.0
+    git+https://github.com/flt6/tts_rebuild
     Deprecated
 
 [options.entry_points]

--- a/src/aspeak/__init__.py
+++ b/src/aspeak/__init__.py
@@ -4,6 +4,6 @@ uses trial auth token of Azure Cognitive Services to do speech synthesis for you
 """
 
 # Re-export some common types to simplify imports on the user side
-from azure.cognitiveservices.speech import SpeechSynthesisOutputFormat, \
+from mytts import SpeechSynthesisOutputFormat, \
     ResultReason, CancellationReason, ResultFuture
 from .api import *

--- a/src/aspeak/api/api.py
+++ b/src/aspeak/api/api.py
@@ -3,11 +3,8 @@ from functools import wraps
 
 from .format import parse_format, AudioFormat, FileFormat
 from ..ssml import create_ssml
-from ..urls import GET_TOKEN
-from requests import get
-from re import search
-from time import time
-import azure.cognitiveservices.speech as speechsdk
+# import azure.cognitiveservices.speech as speechsdk
+import mytts as speechsdk
 
 
 def _parse_kwargs(**kwargs):
@@ -40,19 +37,7 @@ class SpeechServiceBase:
         self._voice = voice
         self._audio_format = audio_format
         self._output = output
-        self._config()
-
-    def _config(self):
-        response = get(GET_TOKEN)
-        response.raise_for_status()
-        html = response.text
-        token = search(r'token: "(.+)"', html)
-        region = search(r'region: "(.+)"', html)
-        assert token is not None
-        assert region is not None
-        self._time = time()
-        self._config = speechsdk.SpeechConfig(
-            region=region.group(1), auth_token="Bearer "+token.group(1))
+        self._config = speechsdk.SpeechConfig()
         if self._locale is not None:
             self._config.speech_synthesis_language = self._locale
         if self._voice is not None:
@@ -63,25 +48,16 @@ class SpeechServiceBase:
         self._synthesizer = speechsdk.SpeechSynthesizer(
             self._config, self._output)
 
-    def _renew(self):
-        now = time()
-        if now-self._time > 290:
-            self._config()
-
     def pure_text_to_speech(self, text, **kwargs):
-        self._renew()
         return self._synthesizer.speak_text(text)
 
     def pure_text_to_speech_async(self, text, **kwargs):
-        self._renew()
         return self._synthesizer.speak_text_async(text)
 
     def ssml_to_speech(self, ssml, **kwargs):
-        self._renew()
         return self._synthesizer.speak_ssml(ssml)
 
     def ssml_to_speech_async(self, ssml, **kwargs):
-        self._renew()
         return self._synthesizer.speak_ssml_async(ssml)
 
     def text_to_speech(self, text, **kwargs):
@@ -95,7 +71,6 @@ class SpeechServiceBase:
         role: The speaking role, optional. It only works for some Chinese voices.
         path: Output file path. Only works with SpeechService classes that support it.
         """
-        self._renew()
         ssml = create_ssml(text, *_parse_kwargs(**kwargs))
         return self._synthesizer.speak_ssml(ssml)
 
@@ -110,7 +85,6 @@ class SpeechServiceBase:
         role: The speaking role, optional. It only works for some Chinese voices.
         path: Output file path. Only works with SpeechService classes that support it.
         """
-        self._renew()
         ssml = create_ssml(text, *_parse_kwargs(**kwargs))
         return self._synthesizer.speak_ssml_async(ssml)
 

--- a/src/aspeak/api/format.py
+++ b/src/aspeak/api/format.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Union
 
-import azure.cognitiveservices.speech as speechsdk
+import mytts as speechsdk
 
 from ..quality import QUALITIES
 

--- a/src/aspeak/api/provider.py
+++ b/src/aspeak/api/provider.py
@@ -1,6 +1,6 @@
 from typing import Union
 from deprecated import deprecated
-import azure.cognitiveservices.speech as speechsdk
+import mytts as speechsdk
 
 
 class SpeechServiceProvider:

--- a/src/aspeak/cli/main.py
+++ b/src/aspeak/cli/main.py
@@ -1,7 +1,7 @@
 import sys
 from functools import partial
 
-import azure.cognitiveservices.speech as speechsdk
+import mytts as speechsdk
 
 from ..api import SpeechToSpeakerService, SpeechToOneFileService
 from ..ssml import create_ssml

--- a/src/aspeak/cli/result_handler.py
+++ b/src/aspeak/cli/result_handler.py
@@ -1,6 +1,6 @@
 import sys
 
-import azure.cognitiveservices.speech as speechsdk
+import mytts as speechsdk
 
 from .constants import COLOR_CLEAR, COLOR_RED
 

--- a/src/aspeak/cli/value_parsers.py
+++ b/src/aspeak/cli/value_parsers.py
@@ -1,4 +1,4 @@
-import azure.cognitiveservices.speech as speechsdk
+import mytts as speechsdk
 
 
 def try_parse_float(arg: str):

--- a/src/aspeak/formats.py
+++ b/src/aspeak/formats.py
@@ -1,4 +1,4 @@
-from azure.cognitiveservices.speech import SpeechSynthesisOutputFormat
+from mytts import SpeechSynthesisOutputFormat
 
 
 def get_available_formats() -> set:

--- a/src/aspeak/quality.py
+++ b/src/aspeak/quality.py
@@ -1,4 +1,4 @@
-from azure.cognitiveservices.speech import SpeechSynthesisOutputFormat
+from mytts import SpeechSynthesisOutputFormat
 
 QUALITIES = {
     'wav': {

--- a/src/aspeak/urls.py
+++ b/src/aspeak/urls.py
@@ -1,4 +1,2 @@
-GET_TOKEN="https://azure.microsoft.com/zh-cn/products/cognitive-services/speech-to-text/"
-
 def voice_list_url() -> str:
     return f'https://eastus.api.speech.microsoft.com/cognitiveservices/voices/list'


### PR DESCRIPTION
I recently finished a rebuild of some essential functions of `azure.cognitiveservices.speech`, and adapted it in `aspeak`.

It has passed all examples, and [my own tts](https://github.com/flt6/tts_rebuild) has ran properly in my own code.