### PR TITLE
Fix token can't get

### DIFF
--- a/src/aspeak/urls.py
+++ b/src/aspeak/urls.py
@@ -1,4 +1,4 @@
-GET_TOKEN="https://azure.microsoft.com/zh-cn/products/cognitive-services/speech-to-text/"
+GET_TOKEN="https://azure.microsoft.com/zh-cn/products/cognitive-services/speech-translation/"
 
 def voice_list_url() -> str:
     return f'https://eastus.api.speech.microsoft.com/cognitiveservices/voices/list'


### PR DESCRIPTION
Due to [speech-to-text](https://azure.microsoft.com/zh-cn/products/cognitive-services/speech-to-text/) page removed the trail demo, the token can't be fetch. Temporarily, we can use [speech-translation](https://azure.microsoft.com/zh-cn/products/cognitive-services/speech-translation/) to get the token instead. 

This can make the main branch available again, but it is highly dependency to the demo page. Using edge Read Aloud api may be better. Adding a token will also be better. In my impletion they are both available.