### PR TITLE
chore: bump rodio to 0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.17.3"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
 dependencies = [
  "claxon",
  "cpal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ reqwest = { version = "0.12.3", default-features = false, features = [
     "json",
     "socks",
 ] }
-rodio = { version = "0.17.1", optional = true }
+rodio = { version = "0.20.1", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.91", optional = true }
 strum = { version = "0.27", features = ["derive"] }
@@ -92,5 +92,5 @@ http-body-util = "0.1.1"
 [dev-dependencies]
 futures = "0.3.28"
 tokio = { version = "1.25.0", features = ["rt", "macros", "fs"] }
-rodio = { version = "0.17.1" }
+rodio = { version = "0.20.1" }
 rustyline = "14.0.0"


### PR DESCRIPTION
The breaking changes shouldn't affect us.

Manually tested.